### PR TITLE
Remove mend from release configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,5 +5,4 @@ changelog:
       - costellobot
       - costellobot[bot]
       - github-actions[bot]
-      - mend[bot]
       - renovate[bot]


### PR DESCRIPTION
The mend bot is no longer going to replace renovate.
